### PR TITLE
Add default values for host and token

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"runtime"
 	"time"
 
@@ -36,13 +37,13 @@ func main() {
 	flaggy.SetDescription("Prometheus exporter for plex")
 	flaggy.SetVersion(info)
 
-	var plexHost string
+	var plexHost = "127.0.0.1"
 	flaggy.String(&plexHost, "H", "host", "Plex address")
 
 	var plexPort = 32400
 	flaggy.Int(&plexPort, "p", "port", "Plex port")
 
-	var plexToken string
+	var plexToken = os.Getenv("PLEX_TOKEN")
 	flaggy.String(&plexToken, "t", "token", "Plex token")
 
 	var metricsPort = "2112"


### PR DESCRIPTION
This PR adds localhost as the default value for the plex host and reads the plex token from the environment by default.
The reason behind this change is that - at least for me - the host is almost always the same as the plex exporter runs on. Reading the token from the env is useful when you run the exporter under `systemd` and don't want to expose it over `ps`.

So now we can run it like this:

```
[Unit]
Description=Service to provide plex metrics

[Service]
EnvironmentFile=/etc/sysconfig/plex_exporter
User=prometheus
ExecStart=/usr/local/bin/plex_exporter

[Install]
WantedBy=multi-user.target
```

and `/etc/sysconfig/plex_exporter`

```
PLEX_TOKEN=ABwZB1RhJlQCGOoCU13r
```